### PR TITLE
Flake8 Fixes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E203, E266, E501, W503
+max-line-length = 120

--- a/src/watchdog/observers/__init__.py
+++ b/src/watchdog/observers/__init__.py
@@ -29,7 +29,7 @@ Classes
    :members:
    :show-inheritance:
    :inherited-members:
-   
+
 Observer thread that schedules watching directories and dispatches
 calls to event handlers.
 
@@ -69,12 +69,12 @@ elif platform.is_darwin():
     # FIXME: catching too broad. Error prone
     try:
         from .fsevents import FSEventsObserver as Observer
-    except:
+    except ImportError:
         try:
             from .kqueue import KqueueObserver as Observer
 
             warnings.warn("Failed to import fsevents. Fall back to kqueue")
-        except:
+        except ImportError:
             from .polling import PollingObserver as Observer
 
             warnings.warn("Failed to import fsevents and kqueue. Fall back to polling.")
@@ -87,10 +87,10 @@ elif platform.is_windows():
     # polling explicitly for Windows XP
     try:
         from .read_directory_changes import WindowsApiObserver as Observer
-    except:
+    except ImportError:
         from .polling import PollingObserver as Observer
 
         warnings.warn("Failed to import read_directory_changes. Fall back to polling.")
 
 else:
-    from .polling import PollingObserver as Observer
+    from .polling import PollingObserver as Observer  # noqa: F401

--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -28,11 +28,22 @@ import sys
 import threading
 import unicodedata
 
-from ..events import (DirCreatedEvent, DirDeletedEvent, DirModifiedEvent,
-                      DirMovedEvent, FileCreatedEvent, FileDeletedEvent,
-                      FileModifiedEvent, FileMovedEvent)
-from ..observers.api import (BaseObserver, DEFAULT_EMITTER_TIMEOUT,
-                             DEFAULT_OBSERVER_TIMEOUT, EventEmitter)
+from ..events import (
+    DirCreatedEvent,
+    DirDeletedEvent,
+    DirModifiedEvent,
+    DirMovedEvent,
+    FileCreatedEvent,
+    FileDeletedEvent,
+    FileModifiedEvent,
+    FileMovedEvent,
+)
+from ..observers.api import (
+    BaseObserver,
+    DEFAULT_EMITTER_TIMEOUT,
+    DEFAULT_OBSERVER_TIMEOUT,
+    EventEmitter,
+)
 from ..utils.dirsnapshot import DirectorySnapshot
 
 
@@ -119,7 +130,7 @@ class FSEventsEmitter(EventEmitter):
             self.pathnames = [self.watch.path]
             _fsevents.add_watch(self, self.watch, callback, self.pathnames)
             _fsevents.read_events(self)
-        except Exception as e:
+        except Exception:
             pass
 
 

--- a/src/watchdog/observers/fsevents2.py
+++ b/src/watchdog/observers/fsevents2.py
@@ -27,30 +27,49 @@ from threading import Thread
 
 # pyobjc
 import AppKit
-from FSEvents import (CFRunLoopGetCurrent, CFRunLoopRun, CFRunLoopStop,
-                      FSEventStreamCreate, FSEventStreamInvalidate,
-                      FSEventStreamRelease, FSEventStreamScheduleWithRunLoop,
-                      FSEventStreamStart, FSEventStreamStop,
-                      kCFAllocatorDefault, kCFRunLoopDefaultMode,
-                      kFSEventStreamCreateFlagFileEvents,
-                      kFSEventStreamCreateFlagNoDefer,
-                      kFSEventStreamEventFlagItemChangeOwner,
-                      kFSEventStreamEventFlagItemCreated,
-                      kFSEventStreamEventFlagItemFinderInfoMod,
-                      kFSEventStreamEventFlagItemInodeMetaMod,
-                      kFSEventStreamEventFlagItemIsDir,
-                      kFSEventStreamEventFlagItemIsSymlink,
-                      kFSEventStreamEventFlagItemModified,
-                      kFSEventStreamEventFlagItemRemoved,
-                      kFSEventStreamEventFlagItemRenamed,
-                      kFSEventStreamEventFlagItemXattrMod,
-                      kFSEventStreamEventIdSinceNow)
+from FSEvents import (
+    CFRunLoopGetCurrent,
+    CFRunLoopRun,
+    CFRunLoopStop,
+    FSEventStreamCreate,
+    FSEventStreamInvalidate,
+    FSEventStreamRelease,
+    FSEventStreamScheduleWithRunLoop,
+    FSEventStreamStart,
+    FSEventStreamStop,
+    kCFAllocatorDefault,
+    kCFRunLoopDefaultMode,
+    kFSEventStreamCreateFlagFileEvents,
+    kFSEventStreamCreateFlagNoDefer,
+    kFSEventStreamEventFlagItemChangeOwner,
+    kFSEventStreamEventFlagItemCreated,
+    kFSEventStreamEventFlagItemFinderInfoMod,
+    kFSEventStreamEventFlagItemInodeMetaMod,
+    kFSEventStreamEventFlagItemIsDir,
+    kFSEventStreamEventFlagItemIsSymlink,
+    kFSEventStreamEventFlagItemModified,
+    kFSEventStreamEventFlagItemRemoved,
+    kFSEventStreamEventFlagItemRenamed,
+    kFSEventStreamEventFlagItemXattrMod,
+    kFSEventStreamEventIdSinceNow,
+)
 
-from ..events import (DirCreatedEvent, DirDeletedEvent, DirModifiedEvent,
-                      DirMovedEvent, FileCreatedEvent, FileDeletedEvent,
-                      FileModifiedEvent, FileMovedEvent)
-from ..observers.api import (BaseObserver, DEFAULT_EMITTER_TIMEOUT,
-                             DEFAULT_OBSERVER_TIMEOUT, EventEmitter)
+from ..events import (
+    DirCreatedEvent,
+    DirDeletedEvent,
+    DirModifiedEvent,
+    DirMovedEvent,
+    FileCreatedEvent,
+    FileDeletedEvent,
+    FileModifiedEvent,
+    FileMovedEvent,
+)
+from ..observers.api import (
+    BaseObserver,
+    DEFAULT_EMITTER_TIMEOUT,
+    DEFAULT_OBSERVER_TIMEOUT,
+    EventEmitter,
+)
 from ..utils.compat import queue
 
 logger = logging.getLogger(__name__)

--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -72,12 +72,24 @@ import os
 import threading
 
 from .inotify_buffer import InotifyBuffer
-from ..events import (DirCreatedEvent, DirDeletedEvent, DirModifiedEvent,
-                      DirMovedEvent, FileCreatedEvent, FileDeletedEvent,
-                      FileModifiedEvent, FileMovedEvent,
-                      generate_sub_created_events, generate_sub_moved_events)
-from ..observers.api import (BaseObserver, DEFAULT_EMITTER_TIMEOUT,
-                             DEFAULT_OBSERVER_TIMEOUT, EventEmitter)
+from ..events import (
+    DirCreatedEvent,
+    DirDeletedEvent,
+    DirModifiedEvent,
+    DirMovedEvent,
+    FileCreatedEvent,
+    FileDeletedEvent,
+    FileModifiedEvent,
+    FileMovedEvent,
+    generate_sub_created_events,
+    generate_sub_moved_events,
+)
+from ..observers.api import (
+    BaseObserver,
+    DEFAULT_EMITTER_TIMEOUT,
+    DEFAULT_OBSERVER_TIMEOUT,
+    EventEmitter,
+)
 from ..utils import unicode_paths
 
 

--- a/src/watchdog/observers/inotify_c.py
+++ b/src/watchdog/observers/inotify_c.py
@@ -451,7 +451,7 @@ class Inotify(object):
         i = 0
         while i + 16 <= len(event_buffer):
             wd, mask, cookie, length = struct.unpack_from("iIII", event_buffer, i)
-            name = event_buffer[i + 16 : i + 16 + length].rstrip(b"\0")
+            name = event_buffer[(i + 16) : (i + 16 + length)].rstrip(b"\0")
             i += 16 + length
             yield wd, mask, cookie, name
 

--- a/src/watchdog/observers/kqueue.py
+++ b/src/watchdog/observers/kqueue.py
@@ -75,12 +75,25 @@ import threading
 
 from pathtools.path import absolute_path
 
-from ..events import (DirCreatedEvent, DirDeletedEvent, DirModifiedEvent,
-                      DirMovedEvent, EVENT_TYPE_CREATED, EVENT_TYPE_DELETED,
-                      EVENT_TYPE_MOVED, FileCreatedEvent, FileDeletedEvent,
-                      FileModifiedEvent, FileMovedEvent)
-from ..observers.api import (BaseObserver, DEFAULT_EMITTER_TIMEOUT,
-                             DEFAULT_OBSERVER_TIMEOUT, EventEmitter)
+from ..events import (
+    DirCreatedEvent,
+    DirDeletedEvent,
+    DirModifiedEvent,
+    DirMovedEvent,
+    EVENT_TYPE_CREATED,
+    EVENT_TYPE_DELETED,
+    EVENT_TYPE_MOVED,
+    FileCreatedEvent,
+    FileDeletedEvent,
+    FileModifiedEvent,
+    FileMovedEvent,
+)
+from ..observers.api import (
+    BaseObserver,
+    DEFAULT_EMITTER_TIMEOUT,
+    DEFAULT_OBSERVER_TIMEOUT,
+    EventEmitter,
+)
 from ..utils import platform
 from ..utils.dirsnapshot import DirectorySnapshot
 

--- a/src/watchdog/observers/polling.py
+++ b/src/watchdog/observers/polling.py
@@ -39,11 +39,22 @@ import os
 import threading
 from functools import partial
 
-from ..events import (DirCreatedEvent, DirDeletedEvent, DirModifiedEvent,
-                      DirMovedEvent, FileCreatedEvent, FileDeletedEvent,
-                      FileModifiedEvent, FileMovedEvent)
-from ..observers.api import (BaseObserver, DEFAULT_EMITTER_TIMEOUT,
-                             DEFAULT_OBSERVER_TIMEOUT, EventEmitter)
+from ..events import (
+    DirCreatedEvent,
+    DirDeletedEvent,
+    DirModifiedEvent,
+    DirMovedEvent,
+    FileCreatedEvent,
+    FileDeletedEvent,
+    FileModifiedEvent,
+    FileMovedEvent,
+)
+from ..observers.api import (
+    BaseObserver,
+    DEFAULT_EMITTER_TIMEOUT,
+    DEFAULT_OBSERVER_TIMEOUT,
+    EventEmitter,
+)
 from ..utils import stat as default_stat
 from ..utils.dirsnapshot import DirectorySnapshot, DirectorySnapshotDiff
 

--- a/src/watchdog/observers/read_directory_changes.py
+++ b/src/watchdog/observers/read_directory_changes.py
@@ -22,14 +22,24 @@ import os.path
 import threading
 import time
 
-from ..events import (DirCreatedEvent, DirModifiedEvent, DirMovedEvent,
-                      FileCreatedEvent, FileDeletedEvent, FileModifiedEvent,
-                      FileMovedEvent, generate_sub_created_events,
-                      generate_sub_moved_events)
-from ..observers.api import (BaseObserver, DEFAULT_EMITTER_TIMEOUT,
-                             DEFAULT_OBSERVER_TIMEOUT, EventEmitter)
-from ..observers.winapi import (close_directory_handle, get_directory_handle,
-                                read_events)
+from ..events import (
+    DirCreatedEvent,
+    DirModifiedEvent,
+    DirMovedEvent,
+    FileCreatedEvent,
+    FileDeletedEvent,
+    FileModifiedEvent,
+    FileMovedEvent,
+    generate_sub_created_events,
+    generate_sub_moved_events,
+)
+from ..observers.api import (
+    BaseObserver,
+    DEFAULT_EMITTER_TIMEOUT,
+    DEFAULT_OBSERVER_TIMEOUT,
+    EventEmitter,
+)
+from ..observers.winapi import close_directory_handle, get_directory_handle, read_events
 
 # HACK:
 WATCHDOG_TRAVERSE_MOVED_DIR_DELAY = 1  # seconds

--- a/src/watchdog/utils/bricks.py
+++ b/src/watchdog/utils/bricks.py
@@ -38,6 +38,7 @@ Classes
 """
 
 import sys
+
 try:
     from collections.abc import MutableSet
 except ImportError:

--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -192,7 +192,7 @@ class DirectorySnapshot(object):
     :param stat:
         Use custom stat function that returns a stat structure for path.
         Currently only st_dev, st_ino, st_mode and st_mtime are needed.
-        
+
         A function with the signature ``walker_callback(path, stat_info)``
         which will be called for every entry in the directory tree.
     :param listdir:


### PR DESCRIPTION
This PR fixes all of the issues raised by flake8, except for the E501 (lines longer than 80 columns) issue, because I think that issue is stupid. Nobody reads or writes code on fixed-width green-on-black terminals from the 1980s anymore, we all use graphical text editors we can resize to view longer lines.

Note that this does **not** fix the issue in PR #16 - that one is a show-stopping logic bug. All of these fixes are simply readability and standardization.

To reproduce, you can run `flake8 src/watchdog --ignore=E501` from the repository root.