### PR TITLE
Python2.7 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@
 # limitations under the License.
 
 import sys
-import importlib.util
 import os.path
 from setuptools import setup, find_packages
 from setuptools.extension import Extension
@@ -29,11 +28,16 @@ from distutils.util import get_platform
 SRC_DIR = "src"
 WATCHDOG_PKG_DIR = os.path.join(SRC_DIR, "watchdog")
 
-spec = importlib.util.spec_from_file_location(
-    "version", os.path.join(WATCHDOG_PKG_DIR, "version.py")
-)
-version = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(version)
+try:
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "version", os.path.join(WATCHDOG_PKG_DIR, "version.py")
+    )
+    version = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(version)
+except ImportError:
+    import imp
+    version = imp.load_source('version', os.path.join(WATCHDOG_PKG_DIR, 'version.py'))
 
 ext_modules = []
 if get_platform().startswith("macosx"):

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,7 @@ class PyTest(TestCommand):
 tests_require = ["pytest", "pytest-cov", "pytest-timeout>=0.3"]
 install_requires = [
     "pathtools3>=0.2.0",
+    "monotonic>=1.5",
     'pyobjc-framework-Cocoa>=4.2.2 ; sys.platform == "darwin"',
     'pyobjc-framework-FSEvents>=4.2.2 ; sys.platform == "darwin"',
 ]

--- a/setup.py
+++ b/setup.py
@@ -94,10 +94,9 @@ class PyTest(TestCommand):
         sys.exit(errno)
 
 
-tests_require = ["pytest", "pytest-cov", "pytest-timeout>=0.3"]
+tests_require = ["monotonic>=1.5", "pytest", "pytest-cov", "pytest-timeout>=0.3"]
 install_requires = [
     "pathtools3>=0.2.0",
-    "monotonic>=1.5",
     'pyobjc-framework-Cocoa>=4.2.2 ; sys.platform == "darwin"',
     'pyobjc-framework-FSEvents>=4.2.2 ; sys.platform == "darwin"',
 ]

--- a/src/watchdog/observers/inotify_c.py
+++ b/src/watchdog/observers/inotify_c.py
@@ -195,10 +195,7 @@ class Inotify(object):
         self._path = path
         self._event_mask = event_mask
         self._is_recursive = recursive
-        if os.path.isdir(path):
-            self._add_dir_watch(path, recursive, event_mask)
-        else:
-            self.add_watch(path)
+        self._add_dir_watch(path, recursive, event_mask)
         self._moved_from_events = dict()
 
     @property

--- a/src/watchdog/observers/inotify_c.py
+++ b/src/watchdog/observers/inotify_c.py
@@ -195,7 +195,10 @@ class Inotify(object):
         self._path = path
         self._event_mask = event_mask
         self._is_recursive = recursive
-        self._add_dir_watch(path, recursive, event_mask)
+        if os.path.isdir(path):
+            self._add_dir_watch(path, recursive, event_mask)
+        else:
+            self.add_watch(path)
         self._moved_from_events = dict()
 
     @property

--- a/src/watchdog/utils/compat.py
+++ b/src/watchdog/utils/compat.py
@@ -14,7 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import queue
+try:
+    import queue
+except ImportError:
+    import Queue as queue
 from threading import Event
 
 __all__ = ["queue", "Event"]

--- a/tests/test_delayed_queue.py
+++ b/tests/test_delayed_queue.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from time import monotonic
+from monotonic import monotonic
 
 from watchdog.utils.delayed_queue import DelayedQueue
 

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -17,12 +17,12 @@
 import os
 import time
 from functools import partial
-from queue import Queue
 
 import pytest
 from watchdog.events import *
 from watchdog.observers.api import ObservedWatch
 from watchdog.utils import platform
+from watchdog.utils.compat import queue as Queue
 from watchdog.utils.unicode_paths import str_cls
 
 from .shell import mkdir, mkdtemp, mv, rm, touch

--- a/tests/test_inotify_c.py
+++ b/tests/test_inotify_c.py
@@ -2,12 +2,12 @@ import contextlib
 import logging
 import os
 from functools import partial
-from queue import Queue
 
 import pytest
 from watchdog.events import DirCreatedEvent, DirDeletedEvent, DirModifiedEvent
 from watchdog.observers.api import ObservedWatch
 from watchdog.utils import platform
+from watchdog.utils.compat import queue as Queue
 
 from .shell import mkdtemp, rm
 

--- a/tests/test_legacy_observers_polling.py
+++ b/tests/test_legacy_observers_polling.py
@@ -19,7 +19,6 @@
 
 
 import os
-import queue
 import unittest
 from time import sleep
 
@@ -29,6 +28,7 @@ from watchdog.events import (DirCreatedEvent, DirDeletedEvent, DirModifiedEvent,
                              FileModifiedEvent, FileMovedEvent)
 from watchdog.observers.api import ObservedWatch
 from watchdog.observers.polling import PollingEmitter as Emitter
+from watchdog.utils.compat import queue
 
 from .shell import mkdir, mkdtemp, mv, rm, touch
 

--- a/tests/test_legacy_observers_winapi.py
+++ b/tests/test_legacy_observers_winapi.py
@@ -19,7 +19,6 @@
 
 
 import os
-import queue
 import unittest
 from time import sleep
 
@@ -27,6 +26,7 @@ import pytest
 from watchdog.events import DirCreatedEvent, DirMovedEvent
 from watchdog.observers.api import ObservedWatch
 from watchdog.utils import platform
+from watchdog.utils.compat import queue
 
 from .shell import mkdir, mkdtemp, mv
 


### PR DESCRIPTION
I depend on the [`monotonic` project](https://pypi.org/project/monotonic) instead of `time.monotopic`. According to its description, "On Python 3.3 or newer, monotonic will be an alias of time.monotonic from the standard library", so it is compatible with both Python 2.7 and Python 3.3+.