### PR TITLE
Add watches for files or directories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,19 +24,78 @@ matrix:
     # Use generic language for osx
     - os: osx
       language: generic
-      env: PYTHON_VERSION=2.7
+      env:
+        - PYTHON_VERSION=2.7
     - os: osx
       language: generic
-      env: PYTHON_VERSION=3.4
+      env:
+        - PYTHON_VERSION=2.7
+        - FSEVENTS_VERSION=1
     - os: osx
       language: generic
-      env: PYTHON_VERSION=3.5
+      env:
+        - PYTHON_VERSION=2.7
+        - FSEVENTS_VERSION=2
+
     - os: osx
       language: generic
-      env: PYTHON_VERSION=3.6
+      env:
+        - PYTHON_VERSION=3.4
     - os: osx
       language: generic
-      env: PYTHON_VERSION=3.7
+      env:
+        - PYTHON_VERSION=3.4
+        - FSEVENTS_VERSION=1
+    - os: osx
+      language: generic
+      env:
+        - PYTHON_VERSION=3.4
+        - FSEVENTS_VERSION=2
+
+    - os: osx
+      language: generic
+      env:
+        - PYTHON_VERSION=3.5
+    - os: osx
+      language: generic
+      env:
+        - PYTHON_VERSION=3.5
+        - FSEVENTS_VERSION=1
+    - os: osx
+      language: generic
+      env:
+        - PYTHON_VERSION=3.5
+        - FSEVENTS_VERSION=2
+
+    - os: osx
+      language: generic
+      env:
+        - PYTHON_VERSION=3.6
+    - os: osx
+      language: generic
+      env:
+        - PYTHON_VERSION=3.6
+        - FSEVENTS_VERSION=1
+    - os: osx
+      language: generic
+      env:
+        - PYTHON_VERSION=3.6
+        - FSEVENTS_VERSION=2
+
+    - os: osx
+      language: generic
+      env:
+        - PYTHON_VERSION=3.7
+    - os: osx
+      language: generic
+      env:
+        - PYTHON_VERSION=3.7
+        - FSEVENTS_VERSION=1
+    - os: osx
+      language: generic
+      env:
+        - PYTHON_VERSION=3.7
+        - FSEVENTS_VERSION=2
 
 before_install:
   - .travis/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,6 +103,7 @@ before_install:
 before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source $HOME/miniconda/bin/activate venv; fi
   - pip install --upgrade setuptools
+  - pip install coveralls
 script:
   - PYTHONPATH=src python setup.py test
 after_script:

--- a/src/watchdog/observers/api.py
+++ b/src/watchdog/observers/api.py
@@ -17,6 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import threading
 
 from ..utils import BaseThread
@@ -105,6 +106,15 @@ class EventEmitter(BaseThread):
         self._event_queue = event_queue
         self._watch = watch
         self._timeout = timeout
+
+    def _normalize_basename(self, pathname):
+        # Chomp ending slashes so os.path.basename gives something useful
+        while os.path.basename(pathname) == '':
+            pathname = pathname[:-1]
+        return os.path.basename(pathname)
+
+    def _normalize_basenames(self, pathnames):
+        return [self._normalize_basename(path) for path in pathnames]
 
     @property
     def timeout(self):
@@ -270,7 +280,7 @@ class BaseObserver(EventDispatcher):
         :type event_handler:
             :class:`watchdog.events.FileSystemEventHandler` or a subclass
         :param path:
-            Directory path that will be monitored.
+            File or directory path that will be monitored.
         :type path:
             ``str``
         :param recursive:

--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -24,6 +24,7 @@
 """
 
 import _watchdog_fsevents as _fsevents
+import os
 import sys
 import threading
 import unicodedata
@@ -67,7 +68,19 @@ class FSEventsEmitter(EventEmitter):
     def __init__(self, event_queue, watch, timeout=DEFAULT_EMITTER_TIMEOUT):
         EventEmitter.__init__(self, event_queue, watch, timeout)
         self._lock = threading.Lock()
-        self.snapshot = DirectorySnapshot(watch.path, watch.is_recursive)
+        self._is_dir = os.path.isdir(self.watch.path)
+        self._file_path = None
+
+        # If the path is not a directory
+        if not self._is_dir:
+            # Save the watched file for later
+            self._file_path = self._normalize_basename(self.watch.path)
+            # Grab its parent directory
+            self._watch._path = os.path.dirname(self.watch.path) or '.'
+            # And don't monitor recursively
+            self._watch._is_recursive = False
+
+        self.snapshot = DirectorySnapshot(self.watch.path, self.watch.is_recursive)
 
     def on_thread_stop(self):
         _fsevents.remove_watch(self.watch)
@@ -81,25 +94,47 @@ class FSEventsEmitter(EventEmitter):
             events = new_snapshot - self.snapshot
             self.snapshot = new_snapshot
 
-            # Files.
-            for src_path in events.files_deleted:
-                self.queue_event(FileDeletedEvent(src_path))
-            for src_path in events.files_modified:
-                self.queue_event(FileModifiedEvent(src_path))
-            for src_path in events.files_created:
-                self.queue_event(FileCreatedEvent(src_path))
-            for src_path, dest_path in events.files_moved:
-                self.queue_event(FileMovedEvent(src_path, dest_path))
+            # If the watched descriptor is a directory, handle it normally
+            if self._is_dir:
+                # Files.
+                for src_path in events.files_deleted:
+                    self.queue_event(FileDeletedEvent(src_path))
+                for src_path in events.files_modified:
+                    self.queue_event(FileModifiedEvent(src_path))
+                for src_path in events.files_created:
+                    self.queue_event(FileCreatedEvent(src_path))
+                for src_path, dest_path in events.files_moved:
+                    self.queue_event(FileMovedEvent(src_path, dest_path))
 
-            # Directories.
-            for src_path in events.dirs_deleted:
-                self.queue_event(DirDeletedEvent(src_path))
-            for src_path in events.dirs_modified:
-                self.queue_event(DirModifiedEvent(src_path))
-            for src_path in events.dirs_created:
-                self.queue_event(DirCreatedEvent(src_path))
-            for src_path, dest_path in events.dirs_moved:
-                self.queue_event(DirMovedEvent(src_path, dest_path))
+                # Directories.
+                for src_path in events.dirs_deleted:
+                    self.queue_event(DirDeletedEvent(src_path))
+                for src_path in events.dirs_modified:
+                    self.queue_event(DirModifiedEvent(src_path))
+                for src_path in events.dirs_created:
+                    self.queue_event(DirCreatedEvent(src_path))
+                for src_path, dest_path in events.dirs_moved:
+                    self.queue_event(DirMovedEvent(src_path, dest_path))
+
+            else:
+                # We only know that the directory changed, so we check for any
+                # changes involving our watched file
+                for src_path in events.files_deleted:
+                    if self._file_path == self._normalize_basename(src_path):
+                        self.queue_event(FileDeletedEvent(src_path))
+
+                for src_path in events.files_modified:
+                    if self._file_path == self._normalize_basename(src_path):
+                        self.queue_event(FileModifiedEvent(src_path))
+
+                for src_path in events.files_created:
+                    if self._file_path == self._normalize_basename(src_path):
+                        self.queue_event(FileCreatedEvent(src_path))
+
+                for src_path, dest_path in events.files_moved:
+                    if self._file_path == self._normalize_basename(src_path) or \
+                       self._file_path == self._normalize_basename(dest_path):
+                        self.queue_event(FileMovedEvent(src_path, dest_path))
 
     def run(self):
         try:

--- a/src/watchdog/observers/inotify_c.py
+++ b/src/watchdog/observers/inotify_c.py
@@ -195,7 +195,10 @@ class Inotify(object):
         self._path = path
         self._event_mask = event_mask
         self._is_recursive = recursive
-        self._add_dir_watch(path, recursive, event_mask)
+        if os.path.isdir(path):
+            self._add_dir_watch(path, recursive, event_mask)
+        else:
+            self.add_watch(path)
         self._moved_from_events = dict()
 
     @property

--- a/src/watchdog/observers/kqueue.py
+++ b/src/watchdog/observers/kqueue.py
@@ -431,6 +431,17 @@ class KqueueEmitter(EventEmitter):
 
         self._kq = select.kqueue()
         self._lock = threading.RLock()
+        self._is_dir = os.path.isdir(self.watch.path)
+        self._file_path = None
+
+        # If the path is not a directory
+        if not self._is_dir:
+            # Save the watched file for later
+            self._file_path = self._normalize_basename(self.watch.path)
+            # Grab its parent directory
+            self._watch._path = os.path.dirname(self.watch.path) or '.'
+            # And don't modify recursively
+            self._watch._is_recursive = False
 
         # A collection of KeventDescriptor.
         self._descriptors = KeventDescriptorSet()
@@ -439,7 +450,7 @@ class KqueueEmitter(EventEmitter):
             self._register_kevent(path, stat.S_ISDIR(stat_info.st_mode))
 
         self._snapshot = DirectorySnapshot(
-            watch.path, watch.is_recursive, walker_callback
+            self.watch.path, self.watch.is_recursive, walker_callback
         )
 
     def _register_kevent(self, path, is_directory):
@@ -577,6 +588,22 @@ class KqueueEmitter(EventEmitter):
                     files_renamed.add(src_path)
         return files_renamed, dirs_renamed, dirs_modified
 
+    def _queue_file_events(self, event_list):
+        files_renamed = set()
+        for kev in event_list:
+            descriptor = self._descriptors.get_for_fd(kev.ident)
+            src_path = descriptor.path
+            if self._file_path == self._normalize_basename(src_path):
+                if is_deleted(kev):
+                    self.queue_event(FileDeletedEvent(src_path))
+                elif is_attrib_modified(kev):
+                    self.queue_event(FileModifiedEvent(src_path))
+                elif is_modified(kev):
+                    self.queue_event(FileModifiedEvent(src_path))
+                elif is_renamed(kev):
+                    files_renamed.add(src_path)
+        return files_renamed
+
     def _queue_renamed(self, src_path, is_directory, ref_snapshot, new_snapshot):
         """
         Compares information from two directory snapshots (one taken before
@@ -648,25 +675,41 @@ class KqueueEmitter(EventEmitter):
         """
         with self._lock:
             try:
-                event_list = self._read_events(timeout)
-                files_renamed, dirs_renamed, dirs_modified = self._queue_events_except_renames_and_dir_modifications(
-                    event_list
-                )
+                if not self._is_dir:
+                    event_list = self._read_events(timeout)
+                    files_renamed = self._queue_file_events(event_list)
 
-                # Take a fresh snapshot of the directory and update the
-                # saved snapshot.
-                new_snapshot = DirectorySnapshot(
-                    self.watch.path, self.watch.is_recursive
-                )
-                ref_snapshot = self._snapshot
-                self._snapshot = new_snapshot
+                    # Take a fresh snapshot of the directory and update the
+                    # saved snapshot.
+                    new_snapshot = DirectorySnapshot(
+                        self.watch.path, self.watch.is_recursive
+                    )
+                    ref_snapshot = self._snapshot
+                    self._snapshot = new_snapshot
 
-                if files_renamed or dirs_renamed or dirs_modified:
                     for src_path in files_renamed:
                         self._queue_renamed(src_path, False, ref_snapshot, new_snapshot)
-                    for src_path in dirs_renamed:
-                        self._queue_renamed(src_path, True, ref_snapshot, new_snapshot)
-                    self._queue_dirs_modified(dirs_modified, ref_snapshot, new_snapshot)
+
+                else:
+                    event_list = self._read_events(timeout)
+                    files_renamed, dirs_renamed, dirs_modified = self._queue_events_except_renames_and_dir_modifications(
+                        event_list
+                    )
+
+                    # Take a fresh snapshot of the directory and update the
+                    # saved snapshot.
+                    new_snapshot = DirectorySnapshot(
+                        self.watch.path, self.watch.is_recursive
+                    )
+                    ref_snapshot = self._snapshot
+                    self._snapshot = new_snapshot
+
+                    if files_renamed or dirs_renamed or dirs_modified:
+                        for src_path in files_renamed:
+                            self._queue_renamed(src_path, False, ref_snapshot, new_snapshot)
+                        for src_path in dirs_renamed:
+                            self._queue_renamed(src_path, True, ref_snapshot, new_snapshot)
+                        self._queue_dirs_modified(dirs_modified, ref_snapshot, new_snapshot)
             except OSError as e:
                 if e.errno == errno.EBADF:
                     # logging.debug(e)

--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -143,6 +143,14 @@ class DirectorySnapshotDiff(object):
         return self._files_moved
 
     @property
+    def files(self):
+        """
+        List of files that had events.
+        """
+        return (self._files_created + self._files_deleted +
+                self._files_modified + self._files_moved)
+
+    @property
     def dirs_modified(self):
         """
         List of directories that were modified.
@@ -172,6 +180,14 @@ class DirectorySnapshotDiff(object):
         List of directories that were created.
         """
         return self._dirs_created
+
+    @property
+    def dirs(self):
+        """
+        List of directories that had events.
+        """
+        return (self.dirs_created + self.dirs_deleted +
+                self.dirs_modified + self.dirs_moved)
 
 
 class DirectorySnapshot(object):

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -35,7 +35,13 @@ if platform.is_linux():
     from watchdog.observers.inotify import InotifyFullEmitter
 elif platform.is_darwin():
     pytestmark = pytest.mark.skip('WATCHDOG-8')
-    from watchdog.observers.fsevents2 import FSEventsEmitter as Emitter
+    if 'FSEVENTS_VERSION' not in os.environ:
+        from watchdog.observers.kqueue import KqueueEmitter as Emitter
+    elif os.environ['FSEVENTS_VERSION'] == 2:
+        from watchdog.observers.fsevents2 import FSEventsEmitter as Emitter
+    else:
+        from watchdog.observers.fsevents import FSEventsEmitter as Emitter
+
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)

--- a/tests/test_legacy_observers_api.py
+++ b/tests/test_legacy_observers_api.py
@@ -61,6 +61,14 @@ class TestEventEmitter(unittest.TestCase):
         event_emitter = EventEmitter(event_queue, watch, timeout=1)
         event_emitter.queue_event(FileModifiedEvent("/foobar/blah"))
 
+    def test__normalize_basename(self):
+        event_queue = EventQueue()
+        watch = ObservedWatch("/foobar", True)
+        event_emitter = EventEmitter(event_queue, watch, timeout=1)
+        self.assertEqual(
+            event_emitter._normalize_basenames(['/dir/thing///////']),
+            ['thing'])
+
 
 class TestEventDispatcher(unittest.TestCase):
     def test_dispatch_event(self):


### PR DESCRIPTION
This allows users to add normal files to be observed, instead of only directories, when using the inotify observer.