### PR TITLE
Fix things and add Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,6 @@ before_install:
 before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source $HOME/miniconda/bin/activate venv; fi
   - pip install --upgrade setuptools
-  - pip install pathtools3 monotonic pytest pytest-cov pytest-timeout coveralls
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip install pyobjc-framework-Cocoa\>=4.2.2 pyobjc-framework-FSEvents\>=4.2.2; fi
 script:
   - PYTHONPATH=src python setup.py test
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,52 @@
+sudo: false
+language: python
+
+matrix:
+  include:
+    # Use the built in venv for linux builds
+    - os: linux
+      sudo: false
+      python: "2.7"
+    - os: linux
+      sudo: false
+      python: "3.4"
+    - os: linux
+      sudo: false
+      python: "3.5"
+    - os: linux
+      sudo: false
+      python: "3.6"
+    # Travis doesn't have Python 3.7 activated yet
+    # - os: linux
+    #   sudo: false
+    #   python: "3.7"
+
+    # Use generic language for osx
+    - os: osx
+      language: generic
+      env: PYTHON_VERSION=2.7
+    - os: osx
+      language: generic
+      env: PYTHON_VERSION=3.4
+    - os: osx
+      language: generic
+      env: PYTHON_VERSION=3.5
+    - os: osx
+      language: generic
+      env: PYTHON_VERSION=3.6
+    - os: osx
+      language: generic
+      env: PYTHON_VERSION=3.7
+
+before_install:
+  - .travis/install.sh
+
+before_script:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source $HOME/miniconda/bin/activate venv; fi
+  - pip install --upgrade setuptools
+  - pip install pathtools3 monotonic pytest pytest-cov pytest-timeout coveralls
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip install pyobjc-framework-Cocoa\>=4.2.2 pyobjc-framework-FSEvents\>=4.2.2; fi
+script:
+  - PYTHONPATH=src python setup.py test
+after_script:
+  - coveralls

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Taken largely from https://stackoverflow.com/q/45257534
+
+
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    if [[ "$PYTHON_VERSION" == "2.7" ]]; then
+        which virtualenv
+        # Create and activate a virtualenv for conda
+        virtualenv -p python condavenv
+        source condavenv/bin/activate
+
+        # Grab Miniconda 2
+        wget https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh -O miniconda.sh
+    else
+        # Install or upgrade to Python 3
+        brew update 1>/dev/null
+        # Simply upgrade if Python 2 has already been installed
+        if brew info python@2 | grep -q "Python has been installed as"; then
+            brew upgrade python
+        else
+            brew install python3
+        fi
+        # Create and activate a virtualenv for conda
+        virtualenv -p python3 condavenv
+        source condavenv/bin/activate
+
+        # Grab Miniconda 3
+        wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
+    fi
+
+    # Install our version of miniconda
+    bash miniconda.sh -b -p $HOME/miniconda
+    # Modify the PATH, even though this doesn't seem to be effective later on
+    export PATH="$HOME/miniconda/bin:$PATH"
+    hash -r
+
+    # Configure conda to act non-interactively
+    conda config --set always_yes yes --set changeps1 no
+    # Update conda to the latest and greatest
+    conda update -q conda
+    # Enable conda-forge for binary packages, if necessary
+    conda config --add channels conda-forge
+    # Useful for debugging any issues with conda
+    conda info -a
+    echo "Creating conda virtualenv with Python $PYTHON_VERSION"
+    conda create -n venv python=$PYTHON_VERSION
+    # For whatever reason, source is not finding the activate script unless we
+    # specify the full path to it
+    source $HOME/miniconda/bin/activate venv
+    # This is the Python that will be used for running tests, so we dump its
+    # version here to help with troubleshooting
+    which python
+    python --version
+fi

--- a/setup.py
+++ b/setup.py
@@ -97,8 +97,8 @@ class PyTest(TestCommand):
 tests_require = ["monotonic>=1.5", "pytest", "pytest-cov", "pytest-timeout>=0.3"]
 install_requires = [
     "pathtools3>=0.2.0",
-    'pyobjc-framework-Cocoa>=4.2.2 ; sys.platform == "darwin"',
-    'pyobjc-framework-FSEvents>=4.2.2 ; sys.platform == "darwin"',
+    'pyobjc-framework-Cocoa>=4.2.2 ; sys_platform == "darwin"',
+    'pyobjc-framework-FSEvents>=4.2.2 ; sys_platform == "darwin"',
 ]
 
 with open("README.rst") as f:

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ try:
     )
     version = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(version)
-except ImportError:
+except (ImportError, AttributeError):
     import imp
     version = imp.load_source('version', os.path.join(WATCHDOG_PKG_DIR, 'version.py'))
 

--- a/tests/test_delayed_queue.py
+++ b/tests/test_delayed_queue.py
@@ -26,4 +26,5 @@ def test_get():
     q.get()
     elapsed = monotonic() - inserted
     # 2.05 instead of 2.01 for slow Windows slaves
-    assert 1.99 < elapsed < 2.05
+    # 2.10 instead of 2.05 for slow Mac OS X slaves on Travis
+    assert 1.99 < elapsed < 2.10

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -242,7 +242,7 @@ def test_fast_subdirectory_creation_deletion():
 
 
 def test_passing_unicode_should_give_unicode():
-    start_watching(p(""))
+    start_watching(str_cls(p("")))
     touch(p("a"))
     event = event_queue.get(timeout=5)[0]
     assert isinstance(event.src_path, str_cls)


### PR DESCRIPTION
I fixed a few things and added Travis configuration.

### Fixes ###

The Unicode test in `tests/test_emitter.py` was passing in a byte string (on Python 2.7) and expecting a Unicode string back - this is now fixed so that it always passes in a Unicode string.

The requirement specifiers were not properly formatted; they are now. See [the documentation](http://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-platform-specific-dependencies) and [PEP 508](https://www.python.org/dev/peps/pep-0508/) for more information on the exact syntax, or check out the table in the [Environment Markers section](https://www.python.org/dev/peps/pep-0508/#environment-markers) of PEP 508.

Travis OS X nodes are apparently just slightly slower than Windows nodes, so I tweaked the cutoff timeout to allow for that.

### Travis Integration ###

Travis support is a little tricky because while they support OS X hosts, they don't natively support the full Python environment on OS X hosts, so I added an install script just for OS X, and a few build steps that only fire on OS X.

The installation script for OS X is a little wonky - it either installs Python 2 and Miniconda 2 in a virtualenv (`condavenv`), or it installs Python 3 and Miniconda 3 in a virtualenv (also `condavenv`). Then it uses Miniconda to create *another* virtualenv (creatively called `venv`), and installs the requested version of Python in that, and that virtualenv is what the tests are run within. I commented the crap out of the installation script so people know what's going on.

It's weird, but it works. The following environments are tested:

| Python | Linux | Mac OS X |
| --- | --- | --- |
| 2.7 | ✅ | ✅ |
| 3.4 | ✅ | ✅ |
| 3.5 | ✅ | ✅ |
| 3.6 | ✅ | ✅ |
| 3.7 |   | ✅ |

See [here](https://travis-ci.org/blag/watchdog3/builds/405669295) for the latest (as of this post) build results.

Oddly enough, OS X has support for Python 3.7 before Travis has support for 3.7 on Linux.

I realize that this adds one more test for you guys, but 99% of developers on GitHub are already familiar with Travis tests, and Travis tests give immediate feedback to users who don't have access to your infrastructure. I poked around your Jenkins site a bit and couldn't figure out why my tests were failing, but Travis is very straightforward.

And lastly, I added a coveralls step at the end, so if you configure Travis for your fork, then configure Coveralls, it should Just Work (tm).